### PR TITLE
Fixed Crash

### DIFF
--- a/src/main/java/eryngii/bountifulblocks/BountifulBlocksCore.java
+++ b/src/main/java/eryngii/bountifulblocks/BountifulBlocksCore.java
@@ -85,8 +85,8 @@ public class BountifulBlocksCore {
 	  //クリエイティブタブ
 	  public static final CreativeTabs tabsMaya = new CreativeTabMaya("Maya");
 	  //村人。
-	  public static VillagerMaya villager;
-	  public static int mayaVillagerProfession = 5;
+	  public static VillagerMaya villagerMaya;
+	  public static int mayaVillagerProfession = 114514;
 	
 	  //プロキシ。Wikiでの登録手法では上手くいかなかったためきっちり登録した
 	  @SidedProxy(clientSide = "eryngii.bountifulblocks.ClientProxy", 
@@ -225,7 +225,7 @@ public class BountifulBlocksCore {
 	        if(FMLCommonHandler.instance().getSide() == Side.CLIENT) {
 			RenderingRegistry.registerEntityRenderingHandler(EntityBonsaiMan.class, new RenderBonsaiMan());
 
-		  villager = new VillagerMaya();
+		  villagerMaya = new VillagerMaya();
 		  
 			/*
 			 * 村人の職業IDを登録しています
@@ -235,7 +235,7 @@ public class BountifulBlocksCore {
 			/*
 			 * 村人を登録しています
 			 */
-			VillagerRegistry.instance().registerVillageTradeHandler(mayaVillagerProfession, villager);
+			VillagerRegistry.instance().registerVillageTradeHandler(mayaVillagerProfession, villagerMaya);
 	 
 			/*
 			 * 村人の家を登録しています

--- a/src/main/java/eryngii/bountifulblocks/ModelBonsaiMan.java
+++ b/src/main/java/eryngii/bountifulblocks/ModelBonsaiMan.java
@@ -124,7 +124,7 @@ public class ModelBonsaiMan  extends ModelBase {
       {
         //ここから下のあらゆる処理は各種動作。ModelBipedという、人型のEntityによく使われる動作をそのまま持ってきている。
     	//植木鉢が連動して動くよう、関節位置を合わせて腕の動きと同じものを登録
-    	//頭の植木は動かなくても問題なさそうなので現在設定せず。今後調整する
+       //頭の植木も頭と連動して動く。
     	  super.render(entity, f, f1, f2, f3, f4, f5);
         setRotationAngles(f, f1, f2, f3, f4, f5, entity);
         head.render(f5);


### PR DESCRIPTION
GVCとの村人ID競合でのクラッシュを解消。もしかするとConfigから設定できたほうがいいかもしれませんが、大規模公開予定のものではないので競合は個別に対処します。
